### PR TITLE
Fix yaw and roll being swapped

### DIFF
--- a/inc/sdgyrodsu/cemuhookadapter.h
+++ b/inc/sdgyrodsu/cemuhookadapter.h
@@ -25,8 +25,8 @@ namespace kmicki::sdgyrodsu
 
         bool IsControllerConnected();
 
-        cemuhook::protocol::MotionData GetMotionData(SdHidFrame const& frame, float &lastAccelRtL, float &lastAccelFtB, float &lastAccelTtB);
-        static void SetMotionData(SdHidFrame const& frame, cemuhook::protocol::MotionData &data, float &lastAccelRtL, float &lastAccelFtB, float &lastAccelTtB);
+        cemuhook::protocol::MotionData GetMotionData(SdHidFrame const& frame, float &lastAccelPitch, float &lastAccelRoll, float &lastAccelYaw);
+        static void SetMotionData(SdHidFrame const& frame, cemuhook::protocol::MotionData &data, float &lastAccelPitch, float &lastAccelRoll, float &lastAccelYaw);
 
         private:
         bool ignoreFirst;
@@ -38,9 +38,9 @@ namespace kmicki::sdgyrodsu
         uint32_t lastInc;
         uint64_t lastTimestamp;
         
-        float lastAccelRtL;
-        float lastAccelFtB;
-        float lastAccelTtB;
+        float lastAccelPitch;
+        float lastAccelRoll;
+        float lastAccelYaw;
 
         int toReplicate;
 

--- a/inc/sdgyrodsu/sdhidframe.h
+++ b/inc/sdgyrodsu/sdhidframe.h
@@ -48,14 +48,14 @@ namespace kmicki::sdgyrodsu
         int16_t RightTrackpadX;
         int16_t RightTrackpadY;
 
-        int16_t AccelAxisRightToLeft; // axis from right side to left side of the SD
-        int16_t AccelAxisTopToBottom; // axis from top side to bottom side of the SD
-        int16_t AccelAxisFrontToBack; // axis from front side to back side of the SD
+        int16_t AccelAxisPitch; // axis from right side to left side of the SD
+        int16_t AccelAxisYaw; // axis from top side to bottom side of the SD
+        int16_t AccelAxisRoll; // axis from front side to back side of the SD
 
         // Gyro + -> movement rotating in unscrewing direction (left) around axis
-        int16_t GyroAxisRightToLeft; // axis from right side to left side of the SD
-        int16_t GyroAxisTopToBottom; // axis from top side to bottom side of the SD
-        int16_t GyroAxisFrontToBack; // axis from front side to back side of the SD
+        int16_t GyroAxisPitch; // axis from right side to left side of the SD
+        int16_t GyroAxisYaw; // axis from top side to bottom side of the SD
+        int16_t GyroAxisRoll; // axis from front side to back side of the SD
 
         int16_t Unknown1;
         int16_t Unknown2;

--- a/src/sdgyrodsu/cemuhookadapter.cpp
+++ b/src/sdgyrodsu/cemuhookadapter.cpp
@@ -90,8 +90,8 @@ namespace kmicki::sdgyrodsu
                 gyroTtB = 0;
 
             data.pitch = (float)gyroRtL/gyro1dps;
-            data.yaw = -(float)gyroFtB/gyro1dps;
-            data.roll = (float)gyroTtB/gyro1dps;
+            data.yaw = -(float)gyroTtB/gyro1dps;
+            data.roll = (float)gyroFtB/gyro1dps;
         }
     }
 

--- a/src/sdgyrodsu/presenter.cpp
+++ b/src/sdgyrodsu/presenter.cpp
@@ -21,29 +21,29 @@ namespace kmicki::sdgyrodsu
         static MotionData md;
         auto incSpan = frame.Increment-lastInc; 
 
-        static float lastAccelRtL = 0;
-        static float lastAccelFtB = 0;
-        static float lastAccelTtB = 0;
+        static float lastAccelPitch = 0;
+        static float lastAccelRoll = 0;
+        static float lastAccelYaw = 0;
 
         if(lastInc && incSpan > maxSpan)
             maxSpan = incSpan;
 
         lastInc = frame.Increment;
 
-        CemuhookAdapter::SetMotionData(frame,md,lastAccelRtL,lastAccelFtB,lastAccelTtB);
+        CemuhookAdapter::SetMotionData(frame,md,lastAccelPitch,lastAccelRoll,lastAccelYaw);
 
         int k=0;
         move(++k,0); printw("INC  : %10d         ",frame.Increment);
         move(++k,0); printw("SPAN : %10d         ",incSpan);
         move(++k,0); printw("MAX  : %10d         ",maxSpan);
         ++k;
-        move(++k,0); printw("A_RL : %10d         ",frame.AccelAxisRightToLeft);
-        move(++k,0); printw("A_TB : %10d         ",frame.AccelAxisTopToBottom);
-        move(++k,0); printw("A_FB:  %10d         ",frame.AccelAxisFrontToBack);
+        move(++k,0); printw("A_P  : %10d         ",frame.AccelAxisPitch);
+        move(++k,0); printw("A_Y  : %10d         ",frame.AccelAxisYaw);
+        move(++k,0); printw("A_R  : %10d         ",frame.AccelAxisRoll);
         ++k;
-        move(++k,0); printw("G_RL : %10d         ",frame.GyroAxisRightToLeft);
-        move(++k,0); printw("G_TB : %10d         ",frame.GyroAxisTopToBottom);
-        move(++k,0); printw("G_FB : %10d         ",frame.GyroAxisFrontToBack);
+        move(++k,0); printw("G_P  : %10d         ",frame.GyroAxisPitch);
+        move(++k,0); printw("G_Y  : %10d         ",frame.GyroAxisYaw);
+        move(++k,0); printw("G_R  : %10d         ",frame.GyroAxisRoll);
         ++k;
         move(++k,0); printw("U1   : %10d         ",frame.Unknown1);
         move(++k,0); printw("U2   : %10d         ",frame.Unknown2);


### PR DESCRIPTION
There is currently a bug with yaw and roll being swapped. This means that for example in order to pan aiming mode in the left-right direction in SSHD I would need to tilt the Steam Deck in the roll axis, as if it's a steering wheel.

Looking at the code I assumed this was due to a confusion from the non-standard naming of the rotational axis variables, but I could be wrong.

I have made a commit to just fix the bug (e6053fa02835b196745c4a4eed3cd629eba1cbac) and also made a commit to rename those variables to the standard names of the rotational axes they represent (1050f25a2726ecd1f605f9911dd1122b7920128b), but that renaming commit can be removed if you want to keep the original names.

I have tested this on my SD, and it works fine, I can now pan first person camera left-to-right in Skyward Sword HD by rotating in the yaw axis instead of needing to rotate in the roll axis as if I am rotating a steering wheel.