### PR TITLE
Add shebang to scripts

### DIFF
--- a/pkg/install.sh
+++ b/pkg/install.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 cd "$(dirname "$(readlink -f "$0")")"
 
 echo "Checking 'usbaccess' user group..."

--- a/pkg/logcurrentrun.sh
+++ b/pkg/logcurrentrun.sh
@@ -1,2 +1,3 @@
-journalctl --user -u sdgyrodsu -b | grep "\[$(systemctl --user status sdgyrodsu | grep 'Main PID' | sed 's/.*PID: \([0-9]\+\).*/\1/')\]" --color=never
+#!/bin/sh
 
+journalctl --user -u sdgyrodsu -b | grep "\[$(systemctl --user status sdgyrodsu | grep 'Main PID' | sed 's/.*PID: \([0-9]\+\).*/\1/')\]" --color=never

--- a/pkg/uninstall.sh
+++ b/pkg/uninstall.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Uninstalling the service"
 systemctl --user -q stop sdgyrodsu.service >/dev/null 2>&1
 systemctl --user -q disable sdgyrodsu.service >/dev/null 2>&1

--- a/pkg/update.sh
+++ b/pkg/update.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Grabbing latest release..."
 if curl -L -O -s https://github.com/kmicki/SteamDeckGyroDSU/releases/latest/download/SteamDeckGyroDSUSetup.zip >/dev/null; then
 	echo "Latest release downloaded."
@@ -25,4 +27,3 @@ cd
 rm -rf $HOME/SteamDeckGyroDSUSetup
 
 exit $code
-


### PR DESCRIPTION
They are required so that system can recognize them as actual script files and
won't try executing them as binaries.