### PR TITLE
Feature: Allow configuration of UDP port

### DIFF
--- a/src/cemuhook/cemuhookserver.cpp
+++ b/src/cemuhook/cemuhookserver.cpp
@@ -92,7 +92,11 @@ namespace kmicki::cemuhook
         sockInServer = sockaddr_in();
 
         sockInServer.sin_family = AF_INET;
-        sockInServer.sin_port = htons(PORT);
+        if (const char* customPort = std::getenv("SERVER_PORT")) {
+          sockInServer.sin_port = std::atoi(customPort);
+        } else {
+          sockInServer.sin_port = htons(PORT);
+        }
         sockInServer.sin_addr.s_addr = INADDR_ANY;
 
         if(bind(socketFd, (sockaddr*)&sockInServer, sizeof(sockInServer)) < 0)

--- a/src/cemuhook/cemuhookserver.cpp
+++ b/src/cemuhook/cemuhookserver.cpp
@@ -92,7 +92,7 @@ namespace kmicki::cemuhook
         sockInServer = sockaddr_in();
 
         sockInServer.sin_family = AF_INET;
-        if (const char* customPort = std::getenv("SERVER_PORT")) {
+        if (const char* customPort = std::getenv("SDGYRO_SERVER_PORT")) {
           sockInServer.sin_port = std::atoi(customPort);
         } else {
           sockInServer.sin_port = htons(PORT);

--- a/src/cemuhook/cemuhookserver.cpp
+++ b/src/cemuhook/cemuhookserver.cpp
@@ -93,7 +93,7 @@ namespace kmicki::cemuhook
 
         sockInServer.sin_family = AF_INET;
         if (const char* customPort = std::getenv("SDGYRO_SERVER_PORT")) {
-          sockInServer.sin_port = std::atoi(customPort);
+          sockInServer.sin_port = htons(std::atoi(customPort));
         } else {
           sockInServer.sin_port = htons(PORT);
         }


### PR DESCRIPTION
Making the UDP server port configurable simplifies testing and simplifies running other cemuhook providers on the same host. It is probably not very important for most users, but it doesn't break anything either.

To keep the efforts as small as the benefit, an environment variable is used instead of a command line argument.